### PR TITLE
Add fallback when no plugin returns a value on getLineHTMLForExport()

### DIFF
--- a/static/css/color.css
+++ b/static/css/color.css
@@ -1,6 +1,6 @@
-.color\:black  { color:black; }
-.color\:red    { color:red; }
-.color\:green  { color:green; }
-.color\:blue   { color:blue; }
-.color\:yellow { color:yellow; }
-.color\:orange { color:orange; }
+[data-color="black"], .color\:black  { color:black; }
+[data-color="red"], .color\:red    { color:red; }
+[data-color="green"], .color\:green  { color:green; }
+[data-color="blue"], .color\:blue   { color:blue; }
+[data-color="yellow"], .color\:yellow { color:yellow; }
+[data-color="orange"], .color\:orange { color:orange; }

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -216,6 +216,11 @@ var textWithColor = function(color, text) {
 var regexWithColor = function(color, text) {
   if (!text) text = "this is " + color;
 
-  return "<span .*class=['|\"].*color:" + color + ".*['|\"].*>" + text + "<\/span>"
+  var regex = "<span .*class=['|\"].*color:" + color + ".*['|\"].*>" + text + "<\/span>";
+  // bug fix: if no other plugin on the Etherpad instance returns a value on getLineHTMLForExport() hook,
+  // data-color=(...) won't be replaced by class=color:(...), so we need a fallback regex
+  var fallbackRegex = "<span .*data-color=['|\"]" + color + "['|\"].*>" + text + "<\/span>";
+
+  return regex + " || " + fallbackRegex;
 }
 


### PR DESCRIPTION
Etherpad only exports context.lineContent on HTML export when at least
one plugin returns a value. If this is the only plugin installed, or if
none of the installed plugins retuns a value, all code made on
exportHTML.js will be ignored. To fix this, it was necessary to add a
fallback style on exported CSS.

This fixes #8.